### PR TITLE
fix: improve LCP by optimizing hero image loading

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -57,6 +57,8 @@ const structuredData = {
 							src={heroImage}
 							alt=""
 							class="block mx-auto rounded-xl shadow-md"
+							loading="eager"
+							fetchpriority="high"
 						/>
 					)
 				}


### PR DESCRIPTION
Adds `loading='eager'` and `fetchpriority='high'` to the blog post hero image to improve Largest Contentful Paint (LCP).