### PR TITLE
Fix/pagefind dark mode text

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -112,11 +112,6 @@
     --pagefind-ui-tag: #374151; /* gray-700 */
   }
 
-  /* Ensure dark mode text colors are applied to PageFind results */
-  :global(.dark #pagefind-search) {
-    color: #e5e7eb;
-  }
-
   :global(.dark .pagefind-ui__result-title),
   :global(.dark .pagefind-ui__result-excerpt),
   :global(.dark .pagefind-ui__result-link),
@@ -126,11 +121,6 @@
 
   :global(.dark .pagefind-ui__result-nested) {
     color: #d1d5db !important;
-  }
-
-  :global(.dark .pagefind-ui__search-input) {
-    color: #e5e7eb;
-    background-color: #1f2937;
   }
 
   dialog {


### PR DESCRIPTION
ダークモードの時のPageFindの検索結果の文字色を黒から白にした。