### PR TITLE
feat(ci): add lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Lint
+        run: npm run lint

--- a/docs/ci_lint_setup/implementation_plan.md
+++ b/docs/ci_lint_setup/implementation_plan.md
@@ -1,0 +1,41 @@
+
+# CI/CD Lint設定 実装計画 (再修正版)
+
+## 概要
+`package.json` に条件分岐ロジックを埋め込む手法（スマートではない手法）を廃止し、GitHub ActionsとGitHubの「Branch Protection Rule（ブランチ保護ルール）」を組み合わせた標準的かつスマートな構成を提案します。
+
+この構成により：
+1. **GitHub Actions**: PRおよびMainブランチに対するLintチェックを自動実行します。
+2. **Branch Protection (推奨設定)**: Lintチェックが通らない限り `main` ブランチへのマージを禁止します。
+3. **Cloudflare Pages**: マージされた（＝Lintを通過した）クリーンなコードのみを自動デプロイします。また、PRのプレビュー環境はLintの結果に関わらずデプロイされます（Cloudflare側でLintを行わないため）。
+
+## ユーザーレビューが必要な事項
+- このフローを実現するには、**GitHubの設定画面での操作**（ブランチ保護ルールの有効化）が必要です。
+- コード上の変更はGitHub Actionsのワークフロー追加のみとなり、既存のビルドコマンドは汚しません。
+
+## 変更内容
+
+### プロジェクトルート
+#### [NEW] .github/workflows/ci.yml
+- Lint (Biome) を実行するワークフロー。
+- トリガー:
+    - `pull_request`: 全ブランチ
+    - `push`: `main` ブランチ
+
+### GitHub設定 (ユーザー作業)
+実装完了後、GitHubリポジトリ設定にて以下を行う必要があります：
+1. `Settings` > `Branches` > `Add rule` (main)
+2. `Require status checks to pass before merging` をオンにする
+3. 作成した `Lint` ジョブを必須チェックとして選択する
+
+これにより、「LintエラーがあるコードはMainに入らない（＝本番デプロイされない）」かつ「PRプレビューは（GitHub Actionsが落ちていても）Cloudflare側で生成される」状態が実現します。
+
+## 検証計画
+### 手動検証
+1. LintエラーになるPRを作成する。
+    - **GitHub Actions**: ❌ (失敗)
+    - **Cloudflare Pages**: ✅ (プレビューデプロイ成功)
+    - **マージ**: ❌ (ブランチ保護によりブロックされる) -> **本番デプロイ不可**
+2. Lintエラーを修正する。
+    - **GitHub Actions**: ✅ (成功)
+    - **マージ**: ✅ (可能になる) -> **本番デプロイ実行**

--- a/docs/ci_lint_setup/task.md
+++ b/docs/ci_lint_setup/task.md
@@ -1,0 +1,7 @@
+
+# タスクリスト
+
+- [x] GitHub ActionsによるLintワークフロー作成 <!-- id: 0 -->
+    - [x] `.github/workflows/ci.yml` 作成 <!-- id: 1 -->
+- [ ] 動作確認 <!-- id: 4 -->
+- [ ] (ユーザー作業) GitHub Branch Protectionの設定 <!-- id: 5 -->

--- a/docs/ci_lint_setup/walkthrough.md
+++ b/docs/ci_lint_setup/walkthrough.md
@@ -1,0 +1,22 @@
+
+# CI/CD Lint設定 ウォークスルー
+
+## 実施した変更
+- `.github/workflows/ci.yml` を作成しました。
+    - PR作成時およびMainブランチへのPush時に `npm run lint` (Biome) を実行します。
+
+## 次のステップ (ユーザー作業)
+
+### 1. Branch Protectionの設定
+この設定を行うことで、Lintエラーがある状態での本番マージを防ぎ、"不壊のデプロイ"を実現します。
+
+1. GitHubリポジトリの **Settings** > **Branches** を開きます。
+2. **Add branch protection rule** をクリックします。
+3. **Branch name pattern** に `main` と入力します。
+4. **Require status checks to pass before merging** にチェックを入れます。
+5. 検索ボックスで **Lint** (CIで定義したジョブ名) を検索し、選択します。
+   - ※まだCIが一度も走っていない場合、候補に出ないことがあります。その場合は一度このPRをPushしてCIを走らせてください。
+6. 画面下部の **Create** をクリックして保存します。
+
+### 2. 動作確認
+- このPRのChecksタブでLintが成功していることを確認してください。


### PR DESCRIPTION
## 概要
CI/CD 環境での Lint (Biome) 自動実行ワークフローを追加しました。

## 変更内容
-  を追加
    - PR作成時およびMainブランチへのPush時に 
> mm21-blog@0.0.1 lint
> biome check .

The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 50.
Checked 27 files in 21ms. No fixes applied.
Found 69 warnings.
Found 1 info. を実行します。
-  配下にタスク、実装計画、ウォークスルーを追加

## 検証
- ローカルでの 
> mm21-blog@0.0.1 lint
> biome check .

The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 50.
Checked 27 files in 22ms. No fixes applied.
Found 69 warnings.
Found 1 info. 通過を確認済み。
- PR作成後、GitHub Actionsが正常に動作することを確認してください。

## 補足
- 本番へのデプロイをLint通過後に限定するため、**Branch Protection Rule** の設定が必要です。詳細は  を参照してください。