### PR TITLE
test(ci): verify lint failure

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,8 @@ const posts = (await getCollection('blog'))
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
   .slice(0, 5);
 
+const x =;
+
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',


### PR DESCRIPTION
This PR introduces a deliberate syntax error to verify that the CI Lint workflow fails correctly.