### PR TITLE
feat: Add slide-in animations to content sections

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -53,12 +53,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 			<hr class="border-gray-200 dark:border-gray-700" />
 
 			{/* Experience Section */}
-			<section>
+			<section class="experience-section">
 				<h2 class="text-2xl font-bold mb-6 scramble-text" data-original-text="Experience">Experience</h2>
 				<div class="space-y-8">
 					{/* Current Role: LINE Yahoo */}
 					<div
-						class="border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
+						class="experience-item opacity-0 transform translate-y-4 border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
 					>
 						<h3 class="text-xl font-semibold">Frontend Development Manager</h3>
 						<p class="text-gray-500 dark:text-gray-400 mb-2">
@@ -104,7 +104,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 					{/* Sky株式会社 */}
 					<div
-						class="border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
+						class="experience-item opacity-0 transform translate-y-4 border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
 					>
 						<h3 class="text-xl font-semibold">
 							Project Leader / Lead Engineer
@@ -126,7 +126,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 					{/* 株式会社ティー・アール・シー */}
 					<div
-						class="border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
+						class="experience-item opacity-0 transform translate-y-4 border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
 					>
 						<h3 class="text-xl font-semibold">System Engineer</h3>
 						<p class="text-gray-500 dark:text-gray-400 mb-2">
@@ -146,10 +146,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 			</section>
 
 			{/* Skills Section */}
-			<section>
+			<section class="skills-section">
 				<h2 class="text-2xl font-bold mb-6 scramble-text" data-original-text="Skills & Certifications">Skills & Certifications</h2>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-					<div>
+					<div class="skills-item opacity-0 transform translate-y-4">
 						<h3 class="text-lg font-semibold mb-3 border-b inline-block">
 							Languages & Frameworks
 						</h3>
@@ -165,7 +165,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 							<li>SQL (Oracle, MySQL, PostgreSQL)</li>
 						</ul>
 					</div>
-					<div>
+					<div class="skills-item opacity-0 transform translate-y-4">
 						<h3 class="text-lg font-semibold mb-3 border-b inline-block">
 							Tools & Qualifications
 						</h3>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -124,7 +124,7 @@ const structuredData = {
 				<div class="grid md:grid-cols-2 gap-6">
 					{
 						projects.map((project) => (
-							<div class="project-item opacity-0 transform translate-y-8 p-6 bg-gray-50 dark:bg-gray-800/50 rounded-2xl border border-gray-100 dark:border-gray-800 hover:border-blue-100 dark:hover:border-blue-900 transition-colors">
+							<div class="project-item opacity-0 transform translate-y-4 p-6 bg-gray-50 dark:bg-gray-800/50 rounded-2xl border border-gray-100 dark:border-gray-800 hover:border-blue-100 dark:hover:border-blue-900 transition-colors">
 								<ProjectCard {...project} />
 							</div>
 						))
@@ -153,7 +153,7 @@ const structuredData = {
 				<ul class="space-y-4">
 					{
 						posts.map((post) => (
-							<li class="post-item opacity-0 transform translate-y-8">
+							<li class="post-item opacity-0 transform translate-y-4">
 								<a
 									href={`/blog/${post.id}/`}
 									class="block group p-6 rounded-2xl bg-white dark:bg-gray-900 hover:shadow-xl dark:hover:bg-gray-800 transition-all duration-300 border border-gray-100 dark:border-gray-800 hover:border-blue-100 dark:hover:border-blue-900 hover:scale-[1.02]"

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -10,12 +10,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   description="My personal projects"
 >
   <main class="max-w-4xl mx-auto px-4 py-8">
-    <section class="text-left">
+    <section class="projects-page-section text-left">
       <h1 class="text-4xl font-bold mb-8 text-center scramble-text" data-original-text="Personal Projects">Personal Projects</h1>
       <div class="space-y-8">
         {
           PROJECTS.map((project) => (
-            <ProjectCard {...project} />
+            <div class="project-item opacity-0 transform translate-y-4">
+              <ProjectCard {...project} />
+            </div>
           ))
         }
       </div>

--- a/src/scripts/animations.ts
+++ b/src/scripts/animations.ts
@@ -142,8 +142,8 @@ export function initAnimations() {
       gsap.to(target, tweenVars);
     });
 
-    // Generalized List Item Animation Function
-    const animateListItems = (itemSelector: string, sectionSelector: string) => {
+    // Generalized Slide-in Animation Function (Bottom to Top, like hero-actions)
+    const animateSlideInItems = (itemSelector: string, sectionSelector: string) => {
       const items = document.querySelectorAll(itemSelector);
       if (items.length > 0) {
         const section = document.querySelector(sectionSelector);
@@ -152,8 +152,9 @@ export function initAnimations() {
         gsap.to(items, {
           y: 0,
           opacity: 1,
-          duration: 0.6,
+          duration: 0.8,
           stagger: 0.1,
+          ease: 'power2.out',
           scrollTrigger: {
             trigger: trigger,
             start: 'top 80%',
@@ -163,10 +164,19 @@ export function initAnimations() {
     };
 
     // Post List Interactions
-    animateListItems('.post-item', '.posts-section');
+    animateSlideInItems('.post-item', '.posts-section');
 
-    // Project List Interactions
-    animateListItems('.project-item', '.projects-section');
+    // Project List Interactions (Homepage)
+    animateSlideInItems('.project-item', '.projects-section');
+
+    // Projects Page - All Projects
+    animateSlideInItems('.project-item', '.projects-page-section');
+
+    // About Page - Experience Items
+    animateSlideInItems('.experience-item', '.experience-section');
+
+    // About Page - Skills Items
+    animateSlideInItems('.skills-item', '.skills-section');
   });
 
   // Fallback for reduced motion: ensure content is visible
@@ -177,6 +187,8 @@ export function initAnimations() {
     gsap.set('.section-header', { opacity: 1 });
     gsap.set('.post-item', { opacity: 1, y: 0 });
     gsap.set('.project-item', { opacity: 1, y: 0 });
+    gsap.set('.experience-item', { opacity: 1, y: 0 });
+    gsap.set('.skills-item', { opacity: 1, y: 0 });
     gsap.set('.animate-blob', { opacity: 1 });
 
     // Ensure scramble text matches final state


### PR DESCRIPTION
## 変更内容

ホームページ、Projectsページ、Aboutページのコンテンツセクションに、統一感のあるスライドインアニメーションを追加しました。

### 実装内容

- **ホームページ**: プロジェクトカードと最近の投稿にアニメーションを追加
- **Projectsページ**: すべてのプロジェクトカードにアニメーションを追加
- **Aboutページ**: ExperienceとSkills & Certificationsセクションにアニメーションを追加

### アニメーション仕様

- **方向**: 下から上へのスライド（y軸）
- **初期位置**: `translate-y-4`（16px下から）
- **duration**: 0.8秒
- **stagger**: 0.1秒（順次表示）
- **easing**: `power2.out`
- **アクセシビリティ**: `prefers-reduced-motion`に対応

### デザイン判断

Block Reveal Animation（タイトルで使用している左から右へのスライド）は、ヒーローセクションのみに限定し、他のセクションには控えめなフェードインアニメーションを採用しました。これにより：

- ✅ ヒーローセクションの特別感を維持
- ✅ コンテンツの可読性を確保
- ✅ 全体的に洗練された印象を実現

### テスト

- [x] ビルド成功
- [x] アニメーションの動作確認
- [x] アクセシビリティ対応確認

## スクリーンショット

（開発サーバーで確認済み）

## 関連Issue

N/A