### PR TITLE
fix: conditionally load pagefind resources to prevent 404 in dev mode

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -99,7 +99,6 @@
     }
 
     // Pagefindのリソースを動的に読み込む
-    // Pagefindのリソースを動的に読み込む
     if (!isDev) {
       if (typeof PagefindUI === 'undefined') {
         const script = document.createElement('script')


### PR DESCRIPTION
This PR fixes an issue where Pagefind resources were being requested in dev mode, causing 404 errors. It conditionally loads the resources only in production builds.