### PR TITLE
fix: biome lint warnings resolution

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,7 @@
       "recommended": true,
       "correctness": {
         "noUnusedVariables": "off",
-        "noUnusedImports": "warn"
+        "noUnusedImports": "off"
       }
     }
   },

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -6,12 +6,13 @@ import type { ImageMetadata } from 'astro';
 import FallbackImage from '@/assets/blog-placeholder-1.jpg';
 import StructuredData from '@/components/StructuredData.astro';
 import { SITE_TITLE } from '@/consts';
+import type { StructuredDataType } from '@/types/structured-data';
 
 interface Props {
   title: string;
   description: string;
   image?: ImageMetadata;
-  structuredData?: Record<string, any>;
+  structuredData?: StructuredDataType;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -2,7 +2,7 @@
 const { href, class: className, ...props } = Astro.props;
 const pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, '');
 const subpath = pathname.match(/[^/]+/g);
-const isActive = href === pathname || href === '/' + (subpath?.[0] || '');
+const isActive = href === pathname || href === `/${subpath?.[0] || ''}`;
 ---
 
 <a

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -1,5 +1,5 @@
 ---
-// biome-ignore lint/correctness/noUnusedImports: Used in template
+
 import { SOCIAL_LINKS } from '@/consts';
 
 interface Props {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,11 +5,12 @@ import Footer from '@/components/Footer.astro';
 import Header from '@/components/Header.astro';
 import ThemeScript from '@/components/ThemeScript.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '@/consts';
+import type { StructuredDataType } from '@/types/structured-data';
 
 interface Props {
   title?: string;
   description?: string;
-  structuredData?: Record<string, any>;
+  structuredData?: StructuredDataType;
 }
 
 const { title = SITE_TITLE, description = SITE_DESCRIPTION, structuredData } = Astro.props;


### PR DESCRIPTION
## 概要
Biomeの `noUnusedImports` ルールによる誤検知を回避するため、設定を無効化しました。同時に、残っていた警告（Warning）および推奨事項（Info）を修正し、リントエラーがゼロになるように対応しました。

## 変更内容
1.  **`biome.json`**:
    *   `noUnusedImports` ルールを `off` に設定。

2.  **`src/components/HeaderLink.astro`**:
    *   文字列結合をテンプレートリテラルに修正（`lint/style/useTemplate`）。

3.  **`src/components/SocialLinks.astro`**:
    *   不要になった `biome-ignore` コメントを削除。

4.  **`src/components/BaseHead.astro`** & **`src/layouts/BaseLayout.astro`**:
    *   `structuredData` プロパティの型を `any` から `StructuredDataType` に変更（`lint/suspicious/noExplicitAny`）。

## 検証
- `npm run lint`: エラー・警告なし
- `npm run build`: 正常終了
