### PR TITLE
feat: WebP ConverterをモノレポとしてProjectsページを更新

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -47,6 +47,7 @@ export const PROJECTS: Project[] = [
       'Vitest',
       'Node.js',
       'Sharp',
+      'tsup',
       'CLI',
       'Monorepo',
     ],


### PR DESCRIPTION
## Summary

- ProjectsページのWebP Converter Web エントリをモノレポ構成に合わせて更新
- タイトルを `WebP Converter Web` → `WebP Converter` に変更
- 説明文をWebアプリとCLIツール（`webp-convert`）の両方を紹介する内容に更新
- `repoUrl` をモノレポ (`webp-converter`) のURLに変更
- タグに `Node.js`, `Sharp`, `CLI`, `Monorepo` を追加

## Test plan

- [ ] Projectsページで「WebP Converter」カードが正しく表示されることを確認
- [ ] タイトル・説明文・タグが更新されていることを確認
- [ ] GitHubリンク（モノレポURL）が正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)