### PR TITLE
perf: GSAPのScrollTriggerをCSS transitions + IntersectionObserverに置き換え

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -57,7 +57,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 				<div class="space-y-8">
 					{/* Current Role: LINE Yahoo */}
 					<div
-						class="experience-item opacity-0 transform translate-y-4 border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
+						class="experience-item border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
 					>
 						<h3 class="text-xl font-semibold">Frontend Engineer</h3>
 						<p class="text-gray-500 dark:text-gray-400 mb-2">
@@ -103,7 +103,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 
 					{/* Sky株式会社 */}
 					<div
-						class="experience-item opacity-0 transform translate-y-4 border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
+						class="experience-item border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
 					>
 						<h3 class="text-xl font-semibold">
 							Project Leader / Lead Engineer
@@ -125,7 +125,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 
 					{/* 株式会社ティー・アール・シー */}
 					<div
-						class="experience-item opacity-0 transform translate-y-4 border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
+						class="experience-item border-l-4 border-gray-200 dark:border-gray-700 pl-4 hover:border-black dark:hover:border-white transition"
 					>
 						<h3 class="text-xl font-semibold">System Engineer</h3>
 						<p class="text-gray-500 dark:text-gray-400 mb-2">
@@ -148,7 +148,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 			<section class="skills-section">
 				<h2 class="text-2xl font-bold mb-6 scramble-text" data-original-text="Skills & Certifications">Skills & Certifications</h2>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-					<div class="skills-item opacity-0 transform translate-y-4">
+					<div class="skills-item">
 						<h3 class="text-lg font-semibold mb-3 border-b inline-block">
 							Languages & Frameworks
 						</h3>
@@ -164,7 +164,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 							<li>SQL (Oracle, MySQL, PostgreSQL)</li>
 						</ul>
 					</div>
-					<div class="skills-item opacity-0 transform translate-y-4">
+					<div class="skills-item">
 						<h3 class="text-lg font-semibold mb-3 border-b inline-block">
 							Tools & Qualifications
 						</h3>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ const structuredData = {
 	<div class="relative overflow-hidden">
 		<!-- Decorative Background Element -->
 		<div
-			class="absolute top-0 right-0 -z-10 w-[800px] h-[800px] bg-gradient-to-br from-blue-100/40 to-purple-100/40 dark:from-blue-900/20 dark:to-purple-900/20 rounded-full blur-3xl opacity-0 animate-blob"
+			class="absolute top-0 right-0 -z-10 w-[800px] h-[800px] bg-gradient-to-br from-blue-100/40 to-purple-100/40 dark:from-blue-900/20 dark:to-purple-900/20 rounded-full blur-3xl animate-blob"
 		>
 		</div>
 
@@ -69,7 +69,7 @@ const structuredData = {
 				</div>
 
 				<div
-					class="hero-actions flex flex-col sm:flex-row gap-4 opacity-0 transform translate-y-4"
+					class="hero-actions flex flex-col sm:flex-row gap-4"
 				>
 					<a
 						href="/about"
@@ -99,7 +99,7 @@ const structuredData = {
 			<!-- Projects Section -->
 			<section class="projects-section mb-20">
 				<div
-					class="flex items-center justify-between mb-8 pb-4 border-b border-gray-100 dark:border-gray-800 opacity-0 section-header"
+					class="flex items-center justify-between mb-8 pb-4 border-b border-gray-100 dark:border-gray-800 section-header"
 				>
 					<h2 class="section-title text-2xl font-bold scramble-text" data-original-text="Projects">Projects</h2>
 					<a
@@ -113,7 +113,7 @@ const structuredData = {
 					</a>
 				</div>
 
-				<div class="mb-8 opacity-0 section-header">
+				<div class="mb-8 section-header">
 					<p class="text-gray-600 dark:text-gray-300 leading-relaxed">
 						個人的に開発しているWebアプリケーションやツールの一部です。<br />
 						技術的な実験や、日常の課題解決のために作っています。
@@ -123,7 +123,7 @@ const structuredData = {
 				<div class="grid md:grid-cols-2 gap-6">
 					{
 						projects.map((project) => (
-							<div class="project-item opacity-0 transform translate-y-4 p-6 bg-gray-50 dark:bg-gray-800/50 rounded-2xl border border-gray-100 dark:border-gray-800 hover:border-blue-100 dark:hover:border-blue-900 transition-colors">
+							<div class="project-item p-6 bg-gray-50 dark:bg-gray-800/50 rounded-2xl border border-gray-100 dark:border-gray-800 hover:border-blue-100 dark:hover:border-blue-900 transition-colors">
 								<ProjectCard {...project} />
 							</div>
 						))
@@ -134,7 +134,7 @@ const structuredData = {
 			<!-- Note Section -->
 			<section class="note-section mb-20">
 				<div
-					class="flex items-center justify-between mb-8 pb-4 border-b border-gray-100 dark:border-gray-800 opacity-0 section-header"
+					class="flex items-center justify-between mb-8 pb-4 border-b border-gray-100 dark:border-gray-800 section-header"
 				>
 					<NoteIcon class="h-8 w-auto text-black dark:text-white" />
 					<a
@@ -151,7 +151,7 @@ const structuredData = {
 				<div class="grid md:grid-cols-2 gap-6">
 					{
 						NOTES.map((article) => (
-							<NoteCard article={article} class="note-item opacity-0 transform translate-y-4" />
+							<NoteCard article={article} class="note-item" />
 						))
 					}
 				</div>
@@ -160,7 +160,7 @@ const structuredData = {
 			<!-- Recent Posts Section -->
 			<section class="posts-section">
 				<div
-					class="flex items-center justify-between mb-8 pb-4 border-b border-gray-100 dark:border-gray-800 opacity-0 section-header"
+					class="flex items-center justify-between mb-8 pb-4 border-b border-gray-100 dark:border-gray-800 section-header"
 				>
 					<h2 class="section-title text-2xl font-bold scramble-text" data-original-text="Recent Posts">Recent Posts</h2>
 					<a
@@ -178,7 +178,7 @@ const structuredData = {
 				<ul class="space-y-4">
 					{
 						posts.map((post) => (
-							<li class="post-item opacity-0 transform translate-y-4">
+							<li class="post-item">
 								<a
 									href={`/blog/${post.id}/`}
 									class="block group p-6 rounded-2xl bg-white dark:bg-gray-900 hover:shadow-xl dark:hover:bg-gray-800 transition-all duration-300 border border-gray-100 dark:border-gray-800 hover:border-blue-100 dark:hover:border-blue-900 hover:scale-[1.02]"

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -15,7 +15,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
       <div class="space-y-8">
         {
           PROJECTS.map((project) => (
-            <div class="project-item opacity-0 transform translate-y-4">
+            <div class="project-item">
               <ProjectCard {...project} />
             </div>
           ))

--- a/src/scripts/animations.ts
+++ b/src/scripts/animations.ts
@@ -115,12 +115,10 @@ export function initAnimations() {
       staggerObserver.observe(el);
     });
 
-  // Scramble Text (GSAP core, triggered by IntersectionObserver)
-  document.querySelectorAll('.scramble-text').forEach((element) => {
-    const target = element as HTMLElement;
+  // Scramble Text (GSAP core, triggered by single shared IntersectionObserver)
+  const scrambleAndAnimate = (target: HTMLElement, delay = 0) => {
     const originalText = target.dataset.originalText || target.innerText;
-
-    const tweenVars: gsap.TweenVars = {
+    gsap.to(target, {
       duration: 1.0,
       scrambleText: {
         text: originalText,
@@ -128,21 +126,25 @@ export function initAnimations() {
         revealDelay: 0.5,
         speed: 0.3,
       },
-    };
+      delay,
+    });
+  };
 
+  const scrambleObserver = createObserver(
+    (entry) => {
+      scrambleAndAnimate(entry.target as HTMLElement);
+    },
+    { rootMargin: '0px 0px -15% 0px' }
+  );
+
+  document.querySelectorAll('.scramble-text').forEach((element) => {
+    const target = element as HTMLElement;
     const rect = target.getBoundingClientRect();
     const isInViewport = rect.top < window.innerHeight * 0.85;
 
     if (isInViewport) {
-      tweenVars.delay = 0.2;
-      gsap.to(target, tweenVars);
+      scrambleAndAnimate(target, 0.2);
     } else {
-      const scrambleObserver = createObserver(
-        () => {
-          gsap.to(target, tweenVars);
-        },
-        { rootMargin: '0px 0px -15% 0px' }
-      );
       scrambleObserver.observe(target);
     }
   });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -154,6 +154,10 @@ main {
    ============================================ */
 
 /* animate-blob */
+.animate-blob {
+  opacity: 0;
+}
+
 .animate-blob.is-visible {
   opacity: 1;
   transition: opacity 2s ease-in-out;
@@ -162,26 +166,27 @@ main {
 /* Fade-in-up + hero-actions */
 .fade-in-up,
 .hero-actions {
+  opacity: 0;
+  transform: translateY(1rem);
   transition:
     opacity 0.8s ease-out,
-    transform 0.8s ease-out,
-    translate 0.8s ease-out;
+    transform 0.8s ease-out;
 }
 
 .fade-in-up.is-visible,
 .hero-actions.is-visible {
-  opacity: 1 !important;
-  transform: none !important;
-  translate: none !important;
+  opacity: 1;
+  transform: none;
 }
 
 /* Section headers */
 .section-header {
+  opacity: 0;
   transition: opacity 0.8s ease-out;
 }
 
 .section-header.is-visible {
-  opacity: 1 !important;
+  opacity: 1;
 }
 
 /* Staggered items */
@@ -190,10 +195,11 @@ main {
 .note-item,
 .experience-item,
 .skills-item {
+  opacity: 0;
+  transform: translateY(1rem);
   transition:
     opacity 0.8s ease-out var(--stagger-delay, 0s),
-    transform 0.8s ease-out var(--stagger-delay, 0s),
-    translate 0.8s ease-out var(--stagger-delay, 0s);
+    transform 0.8s ease-out var(--stagger-delay, 0s);
 }
 
 .post-item.is-visible,
@@ -201,7 +207,6 @@ main {
 .note-item.is-visible,
 .experience-item.is-visible,
 .skills-item.is-visible {
-  opacity: 1 !important;
-  transform: none !important;
-  translate: none !important;
+  opacity: 1;
+  transform: none;
 }


### PR DESCRIPTION
## Summary

- `gsap/ScrollTrigger` を削除し約 **7KB(gzip)** のバンドルサイズ削減
- スクロールトリガーを `IntersectionObserver` + CSS transitions に置き換え
- `reveal-wrap` の2フェーズ block reveal アニメーションは GSAP timeline を維持（IO でトリガー）
- `ScrambleTextPlugin` は GSAP 依存のため gsap core ごと維持
- `prefers-reduced-motion` フォールバック対応済み

## Test plan

- [ ] `npm run dev` でローカル確認（全アニメーション動作・ダークモード・reduced-motion）
- [ ] `npm run build` でビルドエラーなし
- [ ] `npm test` で全E2Eテストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)