### PR TITLE
feat: use apple-touch-icon as default OGP image

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -116,3 +116,10 @@ web_dashboard: false
 # override of the corresponding setting in serena_config.yml, see the documentation there.
 # If null or missing, the value from the global config is used.
 symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -21,12 +21,8 @@ interface Props {
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 const { title, description, image, ogImage, structuredData } = Astro.props;
-const defaultOgImage = new URL('/apple-touch-icon.png', Astro.site);
-const ogImageUrl = ogImage
-  ? new URL(ogImage, Astro.site)
-  : image
-    ? new URL(image.src, Astro.site)
-    : defaultOgImage;
+const ogImageSrc = ogImage ?? image?.src ?? '/apple-touch-icon.png';
+const ogImageUrl = new URL(ogImageSrc, Astro.site);
 ---
 
 <!-- Global Metadata -->


### PR DESCRIPTION
## 概要
- デフォルトのOGP画像をAstroのプレースホルダー画像(`blog-placeholder-1.jpg`)からサイトの`apple-touch-icon.png`に変更しました。
- トップページなどをシェアした際に、サイトのアイコンが表示されるようになります。