### PR TITLE
fix: NoteCardの画像をAstro Imageコンポーネントで最適化しLighthouseスコア改善

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,9 @@ import remarkLinkCardPlus from 'remark-link-card-plus';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://blog.milkmaccya.com',
+  image: {
+    remotePatterns: [{ protocol: 'https' }],
+  },
   markdown: {
     remarkPlugins: [
       [

--- a/src/components/NoteCard.astro
+++ b/src/components/NoteCard.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from 'astro:assets';
 import type { NoteOgp } from '@/lib/note-ogp';
 
 interface Props {
@@ -16,14 +17,13 @@ const { ogp } = Astro.props;
 >
   {ogp.image && (
     <div class="aspect-1200/630 overflow-hidden bg-gray-100 dark:bg-gray-800">
-      <img
+      <Image
         src={ogp.image}
         alt={ogp.title}
-        width="1200"
-        height="630"
+        width={960}
+        height={504}
         class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
         loading="lazy"
-        decoding="async"
       />
     </div>
   )}


### PR DESCRIPTION
## 概要

Lighthouseパフォーマンススコアの低下（#104）に対応するため、NoteCardコンポーネントの画像最適化を実施。

## 原因

#99のPRで追加したnote OGPカードにて、外部URL（note.com CDN）の画像を素の`<img>`タグで表示していたため：
- 画像がJPEG/PNGのままでWebP変換されない
- 1200x630のフルサイズ画像を配信しており、表示サイズより過大

これによりLighthouseの以下の監査が失敗：
- **Serve images in next-gen formats**
- **Properly size images**

## 変更内容

### `astro.config.mjs`
- `image.remotePatterns` を追加してHTTPS外部画像のAstro最適化を許可

### `src/components/NoteCard.astro`
- `<img>` → `<Image>`（`astro:assets`）に変更
- ビルド時にWebP形式へ自動変換
- 表示サイズに合わせた `width={960} height={504}` に変更（元の1200x630から縮小）

## 期待する効果

- Lighthouseパフォーマンススコアの改善（79 → 85以上を目標）
- 画像のWebP変換によるファイルサイズ削減
- 適切なサイズの画像配信による帯域節約

Closes #104