### PR TITLE
fix: remove HTML comments causing Astro compiler build failure

### DIFF
--- a/src/components/GoogleTagManager.astro
+++ b/src/components/GoogleTagManager.astro
@@ -8,10 +8,8 @@ const { id, part = 'head' } = Astro.props;
 ---
 
 {part === 'head' && (
-  <!-- Google Tag Manager preconnect -->
   <link rel="preconnect" href="https://www.googletagmanager.com" />
   <link rel="dns-prefetch" href="//www.googletagmanager.com" />
-  <!-- Google Tag Manager (deferred to reduce TBT impact) -->
   <script is:inline set:html={`
     window.addEventListener('load', function() {
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -21,12 +19,9 @@ const { id, part = 'head' } = Astro.props;
       })(window,document,'script','dataLayer',${JSON.stringify(id)});
     });
   `} />
-  <!-- End Google Tag Manager -->
 )}
 
 {part === 'body' && (
-  <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src={`https://www.googletagmanager.com/ns.html?id=${id}`}
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
 )}


### PR DESCRIPTION
## Summary
- CI's `Lint` workflow (Playwright/E2E test job) has been failing on every run since the 2026-06-15 Astro monorepo bump (astro 6.1.0 → 6.4.6, PR #155), which itself already showed CI failures before being merged.
- Root cause: `src/components/GoogleTagManager.astro` had bare HTML comments as the first/last children inside `{cond && (...)}` expression blocks. Astro's compiler throws `Unexpected token` at build time for this pattern, which breaks `npm run build`, which breaks Playwright's `webServer` startup, failing all E2E tests.
- Fix: remove the decorative HTML comments from inside the expression blocks. No functional/behavioral change to the GTM snippet output.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npx playwright test` — all 9 tests pass locally
- [ ] Confirm CI (`Lint` workflow) goes green on this PR (this is the real verification, since the failure did not reproduce locally on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)